### PR TITLE
Enlace a guía instalación linux GUL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@
 </html>
 
 * Enlaces adicionales:
-  * [Jaime Pons |- AprendoLinux](https://www.youtube.com/channel/UCaA0nwerdKCGE7F_doNWdGg)
+  * [Guía de instalación de Linux del GUL](https://github.com/guluc3m/linux404)
+  * [Jaime Pons | AprendoLinux](https://www.youtube.com/channel/UCaA0nwerdKCGE7F_doNWdGg)
   * [www.aprendolinux.com](https://www.aprendolinux.com)
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 </html>
 
 * Enlaces adicionales:
-  * [Guía de instalación de Linux del GUL](https://github.com/guluc3m/linux404)
+  * [Guía de instalación de Linux del GUL](https://github.com/guluc3m/linux-install)
   * [Jaime Pons | AprendoLinux](https://www.youtube.com/channel/UCaA0nwerdKCGE7F_doNWdGg)
   * [www.aprendolinux.com](https://www.aprendolinux.com)
 


### PR DESCRIPTION
Ahora que estamos dejando la guía de instalación de Linux bien maja, estaría bien incluír un link.